### PR TITLE
Added linux support

### DIFF
--- a/backend/Makefile.am
+++ b/backend/Makefile.am
@@ -34,6 +34,13 @@ CFLAGS  += -L"deps/winpcap/lib"
 LIBS    += -lwpcap
 DEST     = $(top_builddir)/xpi/platform/WINNT_x86-msvc
 endif
+if PLATFORM_LINUX
+SOURCES += src/linux_platform.cpp
+CFLAGS  += -DPLATFORM_LINUX
+CFLAGS  += -lpcap
+DEST     = $(top_builddir)/xpi/platform/Linux_x86_64-gcc3
+endif
+
 
 TARGET = $(DEST)/firesheep-backend
 

--- a/backend/Makefile.am
+++ b/backend/Makefile.am
@@ -38,7 +38,7 @@ if PLATFORM_LINUX
 SOURCES += src/linux_platform.cpp
 CFLAGS  += -DPLATFORM_LINUX
 CFLAGS  += -lpcap
-DEST     = $(top_builddir)/xpi/platform/Linux_x86_64-gcc3
+DEST     = $(top_builddir)/xpi/platform/Linux_$(build_cpu)-gcc3
 endif
 
 

--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -47,7 +47,7 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
       }
 
       if (pcap_datalink(interface) == DLT_EN10MB) {
-        const char *description = (dev->description) ? dev->description : "";
+        const char *description = (dev->description) ? dev->description : dev->name;
         InterfaceInfo info(dev->name, description, "ethernet");
         result.push_back(info);
       }

--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -1,11 +1,11 @@
 //
-// osx_platform.cpp: Mac OS X functions
+// linux_platform.cpp: Linux functions, though more unix/pcap general
 // Part of the Firesheep project.
 //
 // Copyright (C) 2010 Eric Butler
 //
 // Authors:
-//   Eric Butler <eric@codebutler.com>
+//   Michajlo Matijkiw
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -1,0 +1,61 @@
+//
+// osx_platform.cpp: Mac OS X functions
+// Part of the Firesheep project.
+//
+// Copyright (C) 2010 Eric Butler
+//
+// Authors:
+//   Eric Butler <eric@codebutler.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <stdio.h>
+#include <pcap/pcap.h>
+#include "linux_platform.hpp"
+
+
+LinuxPlatform::LinuxPlatform(vector<string> argv) : UnixPlatform(argv) { }
+
+bool LinuxPlatform::run_privileged() {
+    return true;
+}
+
+vector<InterfaceInfo> LinuxPlatform::interfaces()
+{
+  vector<InterfaceInfo> result;
+  char err_buff[PCAP_ERRBUF_SIZE];
+  pcap_if_t *all_devs;
+  if (pcap_findalldevs(&all_devs, err_buff) == 0) {
+    pcap_if_t *dev = all_devs;
+    while (dev) {
+      pcap_t *interface = pcap_open_live(dev->name, 1024 ,1, 100, err_buff);
+
+      if (interface == NULL) {
+        dev = dev->next;
+        continue;
+      }
+
+      if (pcap_datalink(interface) == DLT_EN10MB) {
+        const char *description = (dev->description) ? dev->description : "";
+        InterfaceInfo info(dev->name, description, "ethernet");
+        result.push_back(info);
+      }
+
+      pcap_close(interface);
+      dev = dev->next;
+    }
+    pcap_freealldevs(all_devs);
+  }
+  return result; 
+}

--- a/backend/src/linux_platform.hpp
+++ b/backend/src/linux_platform.hpp
@@ -1,0 +1,36 @@
+//
+// osx_platform.h: Mac OS X functions
+// Part of the Firesheep project.
+//
+// Copyright (C) 2010 Eric Butler
+//
+// Authors:
+//   Eric Butler <eric@codebutler.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef FIRESHEEP_LINUX_PLATFORM_H
+#define FIRESHEEP_LINUX_PLATFORM_H
+
+#include "unix_platform.hpp"
+#include "interface_info.hpp"
+
+class LinuxPlatform : public UnixPlatform {
+public:
+  LinuxPlatform(vector<string>);
+  bool run_privileged();
+  vector<InterfaceInfo> interfaces();
+};
+
+#endif

--- a/backend/src/linux_platform.hpp
+++ b/backend/src/linux_platform.hpp
@@ -1,10 +1,11 @@
 //
-// osx_platform.h: Mac OS X functions
+// linux_platform.h: Linux functions, though more unix/pcap general
 // Part of the Firesheep project.
 //
 // Copyright (C) 2010 Eric Butler
 //
 // Authors:
+//   Michajlo Matijkiw
 //   Eric Butler <eric@codebutler.com>
 //
 // This program is free software: you can redistribute it and/or modify

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -27,8 +27,12 @@
 
 #ifdef PLATFORM_WIN32
 #include "windows_platform.hpp"
-#else
+#elif PLATFORM_OSX
 #include "osx_platform.hpp"
+#elif PLATFORM_LINUX
+#include "linux_platform.hpp"
+#else
+#error "no suitable platform"
 #endif
 
 void received_packet(HttpPacket *packet);
@@ -40,8 +44,10 @@ int main(int argc, const char *argv[])
   
 #ifdef PLATFORM_WIN32
   WindowsPlatform platform(sargv);
-#else
+#elif PLATFORM_OSX
   OSXPlatform platform(sargv);
+#else
+  LinuxPlatform platform(sargv);
 #endif
   
   if (argc > 1) {
@@ -112,7 +118,7 @@ void list_interfaces(AbstractPlatform *platform)
   vector<InterfaceInfo>::iterator iter;
   for (iter = interfaces.begin(); iter != interfaces.end(); ++iter) {
     InterfaceInfo iface = *iter;
-    
+ 
     json_spirit::Object iface_obj;
     iface_obj.push_back(json_spirit::Pair("name", iface.name()));
     iface_obj.push_back(json_spirit::Pair("type", iface.type()));

--- a/backend/src/unix_platform.hpp
+++ b/backend/src/unix_platform.hpp
@@ -29,7 +29,11 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include <unistd.h>
+#ifdef PLATFORM_LINUX
+#include <limits.h>
+#else
 #include <sys/syslimits.h>
+#endif
 #include <sys/stat.h>
 #include <sys/errno.h>
 #include "abstract_platform.hpp"

--- a/mozpopen/Makefile.am
+++ b/mozpopen/Makefile.am
@@ -41,7 +41,7 @@ clean:
 endif
 if PLATFORM_LINUX
 SOURCES  = MozPopenModule.cpp unix/MozPopenProcess.cpp
-PLAT_DEST = $(top_builddir)/xpi/platform/Linux_x86_64-gcc3/components
+PLAT_DEST = $(top_builddir)/xpi/platform/Linux_$(build_cpu)-gcc3/components
 CFLAGS  += -Iunix/ -I.
 COMPONENT_NAME = MozPopen
 XPT = $(DEST)/$(COMPONENT_NAME).xpt

--- a/mozpopen/Makefile.am
+++ b/mozpopen/Makefile.am
@@ -39,3 +39,27 @@ $(LIB): $(SOURCES)
 clean:
 	rm -f $(COMPONENT).xpt $(COMPONENT).dylib
 endif
+if PLATFORM_LINUX
+SOURCES  = MozPopenModule.cpp unix/MozPopenProcess.cpp
+PLAT_DEST = $(top_builddir)/xpi/platform/Linux_x86_64-gcc3/components
+CFLAGS  += -Iunix/ -I.
+COMPONENT_NAME = MozPopen
+XPT = $(DEST)/$(COMPONENT_NAME).xpt
+LIB = $(PLAT_DEST)/$(COMPONENT_NAME).so
+
+all: $(XPT) $(COMPONENT_NAME).h $(LIB)
+
+$(COMPONENT_NAME).h: $(COMPONENT_NAME).idl
+	$(XPIDL) -m header $(XPIDL_FLAGS) -e $@ $(COMPONENT_NAME).idl
+
+$(XPT): $(COMPONENT_NAME).idl
+	mkdir -p $(DEST)
+	$(XPIDL) -m typelib $(XPIDL_FLAGS) -e $@ $(COMPONENT_NAME).idl
+
+$(LIB): $(SOURCES)
+	mkdir -p $(PLAT_DEST)
+	$(CXX) -shared -fno-rtti -fPIC $(SOURCES) $(CFLAGS) $(MOZ_CFLAGS) $(MOZ_LIBS) -o $@
+
+clean:
+	rm -f $(COMPONENT).xpt $(COMPONENT).so
+endif

--- a/xpi/install.rdf
+++ b/xpi/install.rdf
@@ -15,6 +15,7 @@
     <em:unpack>true</em:unpack>
     <em:targetPlatform>Darwin_x86-gcc3</em:targetPlatform>
     <em:targetPlatform>WINNT_x86-msvc</em:targetPlatform>
+    <em:targetPlatform>Linux_x86_64-gcc3</em:targetPlatform>
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->

--- a/xpi/install.rdf
+++ b/xpi/install.rdf
@@ -15,6 +15,7 @@
     <em:unpack>true</em:unpack>
     <em:targetPlatform>Darwin_x86-gcc3</em:targetPlatform>
     <em:targetPlatform>WINNT_x86-msvc</em:targetPlatform>
+    <em:targetPlatform>Linux_x86-gcc3</em:targetPlatform>
     <em:targetPlatform>Linux_x86_64-gcc3</em:targetPlatform>
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
Added basic linux support using what's available in libpcacp.  I have it running on my laptop and i can see my sessions getting picked up, though i don't have an unencrypted network to test it on for external sessions, but I'm pretty confident it will work.

Note, you will need to run firesheep-backend --fix-permissions as root manually, I couldn't think of a common linux privilege escalating scheme except 'su'.

Finally, it shouldn't conflict with OSX or windows versions, though I don't have the environments handy to build and check.
