### PR TITLE
Make Facebook/Twitter/Google handlers request over HTTPS

### DIFF
--- a/xpi/handlers/facebook.js
+++ b/xpi/handlers/facebook.js
@@ -1,8 +1,9 @@
 // Authors:
 //   Eric Butler <eric@codebutler.com>
+//   Ian Gallagher <crash@neg9.org>
 register({
   name: 'Facebook',
-  url: 'http://www.facebook.com/home.php',
+  url: 'https://www.facebook.com/home.php',
   domains: [ 'facebook.com' ],
   sessionCookieNames: [ 'xs', 'c_user', 'sid' ],
 

--- a/xpi/handlers/google.js
+++ b/xpi/handlers/google.js
@@ -18,7 +18,7 @@ register({
     // Grab avatar from Google Profiles page, if they have one
     var avatar_element;
     try {
-	    var profile = this.httpGet('http://www.google.com/profiles/me');
+	    var profile = this.httpGet('https://www.google.com/profiles/me');
 	    avatar_element = profile.body.querySelector('.ll_profilephoto.photo');
     }
     catch(err) {

--- a/xpi/handlers/twitter.js
+++ b/xpi/handlers/twitter.js
@@ -1,9 +1,11 @@
 // Authors:
 //   Eric Butler <eric@codebutler.com>
+//   Ian Gallagher <crash@neg9.org>
 Components.utils.import('resource://firesheep/util/RailsHelper.js');
 
 register({
   name: 'Twitter',
+  url: 'https://twitter.com/',
   domains: [ 'twitter.com' ],
   sessionCookieNames: [ '_twitter_sess', 'auth_token' ],
 


### PR DESCRIPTION
Patch to make FB/Twitter/Google handlers request via HTTPS
