### PR TITLE
Allow for missing 'info' HAL properties

### DIFF
--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -42,13 +42,24 @@ bool LinuxPlatform::run_privileged() {
 string device_get_property_string(LibHalContext *context, string device, string key, DBusError *error)
 {
   char *buf = libhal_device_get_property_string(context, device.c_str(), key.c_str(), error);
+
+  string property;
   if (dbus_error_is_set(error)) {
-    dbus_error_free(error);
-    return string("Unknown");
+    if (key.compare(0, 5, "info.") != 0) {
+      runtime_error ex(str(format("libhal_device_get_property_string failed: %s %s") % error->name % error->message));
+      dbus_error_free(error);
+      throw ex;
+    }
+    else {
+      dbus_error_free(error);
+      property = "Unknown";
+    }
   }
   else {
-    return string(buf);
+    property = string(buf);
   }
+
+  return property;
 }
 
 vector<InterfaceInfo> LinuxPlatform::interfaces()

--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -43,11 +43,12 @@ string device_get_property_string(LibHalContext *context, string device, string 
 {
   char *buf = libhal_device_get_property_string(context, device.c_str(), key.c_str(), error);
   if (dbus_error_is_set(error)) {
-    runtime_error ex(str(format("libhal_device_get_property_string failed: %s %s") % error->name % error->message));
     dbus_error_free(error);
-    throw ex;
+    return string("Unknown");
   }
-  return string(buf);
+  else {
+    return string(buf);
+  }
 }
 
 vector<InterfaceInfo> LinuxPlatform::interfaces()


### PR DESCRIPTION
When I run `./firesheep-backend --list-interfaces` on my Ubuntu 10.10 x64 system, `device_get_property_string` throws an exception because one of my interfaces does not have the `info.vendor` property set (a VirtualBox virtual interface).  I modified `device_get_property_string` to return "Unknown" for property keys that start with `info.`, which should be safe.
