### PR TITLE
FIX: Original directory name is lowercased, and this makes Firesheep back

### DIFF
--- a/xpi/modules/Firesheep.js
+++ b/xpi/modules/Firesheep.js
@@ -143,7 +143,7 @@ var Firesheep = {
 
     // Backend is compiled as a universal binary for OSX.
     if (xulRuntime.OS == "Darwin") {
-      dir.append("OSX");
+      dir.append("osx");
 
     } else {
       var platformName = [ xulRuntime.OS, xulRuntime.XPCOMABI ].join('_');


### PR DESCRIPTION
FIX: Original directory name is lowercased, and this makes Firesheep backend fail to start on case-sensitive filesystems.
