### PR TITLE
Making HAL dependency optional

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "backend/deps/http-parser"]
 	path = backend/deps/http-parser
-	url = git://github.com/ry/http-parser.git
+	url = git://github.com/joyent/http-parser

--- a/backend/src/linux_platform.cpp
+++ b/backend/src/linux_platform.cpp
@@ -26,7 +26,10 @@
 #include <cstdio>
 #include <pcap/pcap.h>
 #include "linux_platform.hpp"
+
+#ifndef DISABLE_HAL
 #include <libhal.h>
+#endif
 
 using namespace std;
 using namespace boost;
@@ -43,6 +46,7 @@ bool LinuxPlatform::run_privileged()
   return (ret == 0);
 }
 
+#ifndef DISABLE_HAL
 string device_get_property_string(LibHalContext *context, string device, string key, DBusError *error)
 {
   char *buf = libhal_device_get_property_string(context, device.c_str(), key.c_str(), error);
@@ -53,11 +57,14 @@ string device_get_property_string(LibHalContext *context, string device, string 
   }
   return string(buf);
 }
+#endif
 
 vector<InterfaceInfo> LinuxPlatform::interfaces()
 {
   vector<InterfaceInfo> result;
-  
+
+#ifndef DISABLE_HAL
+
   DBusError     error;
   LibHalContext *context;
   char          **devices;
@@ -67,7 +74,7 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
   context = libhal_ctx_new();
   if (context == NULL)
     throw runtime_error("libhal_ctx_new() failed");
-    
+
   /* Initialize DBus connection */
   dbus_error_init(&error); 
   if (!libhal_ctx_set_dbus_connection(context, dbus_bus_get(DBUS_BUS_SYSTEM, &error))) {
@@ -75,7 +82,7 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
     LIBHAL_FREE_DBUS_ERROR(&error);
     throw ex;
   }
-    
+
   /* Initialize HAL context */
   if (!libhal_ctx_init(context, &error)) {
     if (dbus_error_is_set(&error)) {
@@ -94,7 +101,7 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
 
   for (int i = 0; i < num_devices; i++) {
     char *device = devices[i];
-    
+
     /* Get basic device information */
     string iface    = device_get_property_string(context, devices[i], "net.interface", &error);
     string category = device_get_property_string(context, devices[i], "info.category", &error);
@@ -108,7 +115,7 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
       type = "ethernet";
     else
       continue;
-      
+
     /* device points to a 'network inteface', get parent (physical?) device */
     string parent = device_get_property_string(context, device, "net.originating_device", &error);
 
@@ -126,14 +133,34 @@ vector<InterfaceInfo> LinuxPlatform::interfaces()
     string vendor  = device_get_property_string(context, parent, "info.vendor", &error);
     string product = device_get_property_string(context, parent, "info.product", &error);
     string description(str(format("%s %s") % vendor % product));
-    
+
     InterfaceInfo info(iface, description, type);
     result.push_back(info);
   }
-  
+
   /* Free devices */
   libhal_free_string_array(devices);
+#else
+  pcap_if_t *alldevs;
+  pcap_if_t *d;
+  char errbuf[PCAP_ERRBUF_SIZE+1];
 
-  return result; 
+  if (pcap_findalldevs(&alldevs, errbuf) == -1) {
+    throw runtime_error(str(boost::format("Error in pcap_findalldevs: %s") % errbuf));
+  }
+
+  for (d = alldevs; d; d = d->next) {
+    string id(d->name);
+    boost::replace_all(id, "\\", "\\\\");
+    boost::replace_all(id, "{", "\\{");
+    boost::replace_all(id, "}", "\\}");
+    InterfaceInfo info(id, (string(d->description ? d->description : "No description")), "ethernet");
+    result.push_back(info);
+  }
+
+  pcap_freealldevs(alldevs);
+#endif
+
+  return result;
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,9 +100,19 @@ AC_SUBST(BOOST_STRING_ALGO_LIBS)
 # END BOOST LIBS
 
 if test x$FIRESHEEP_PLATFORM_NAME = xLINUX; then
-	PKG_CHECK_MODULES(HAL, [hal])
+	AC_MSG_CHECKING(if --enable-hal option is specified)
+	AC_ARG_ENABLE(hal, [  --enable-hal           enable HAL interface listing])
+
+	if test "$enable_hal" = "yes"; then
+		PKG_CHECK_MODULES(HAL, [hal])
+	else
+		HAL_CFLAGS="-DDISABLE_HAL"
+		HAL_LIBS=""
+	fi
+
 	AC_SUBST(HAL_CFLAGS)
 	AC_SUBST(HAL_LIBS)
+	AC_MSG_RESULT(${enable_hal-no})
 fi
 
 CXXFLAGS="-Wall -g -O0"


### PR DESCRIPTION
This simple patch just make the libhal dependency optional.
