### PR TITLE
Fix use-after-free bugs

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -63,8 +63,8 @@ int main(int argc, const char *argv[])
     string filter(argv[2]);
     
     if (argc > 4) {
-      freopen(string(argv[3]).c_str(), "w", stdout);
-      freopen(string(argv[4]).c_str(), "w", stderr);
+      freopen(argv[3], "w", stdout);
+      freopen(argv[4], "w", stderr);
       
       // rw-rw-rw-
       mode_t mode = S_IFREG | 

--- a/backend/src/osx_platform.cpp
+++ b/backend/src/osx_platform.cpp
@@ -39,7 +39,7 @@ bool OSXPlatform::run_privileged()
   OSStatus           err;
   AuthorizationFlags flags;
   
-  const char *path = this->path().c_str();
+  const string &path = this->path();
   
   flags = kAuthorizationFlagExtendRights | kAuthorizationFlagInteractionAllowed;
   
@@ -49,7 +49,7 @@ bool OSXPlatform::run_privileged()
   
   char *args[] = { (char *) "--fix-permissions", NULL };
   
-  err = AuthorizationExecuteWithPrivileges(auth, path, kAuthorizationFlagDefaults, args, NULL);
+  err = AuthorizationExecuteWithPrivileges(auth, path.c_str(), kAuthorizationFlagDefaults, args, NULL);
   AuthorizationFree(auth, kAuthorizationFlagDefaults);
   if (err == errAuthorizationCanceled)
     return false;

--- a/backend/src/unix_platform.hpp
+++ b/backend/src/unix_platform.hpp
@@ -111,7 +111,7 @@ protected:
     char path[PATH_MAX];
     if (!realpath(m_path.c_str(), path))
       throw runtime_error(str(boost::format("realpath() failed: %d\n") % errno));
-    return m_path;
+    return string(path);
   }
 
 private:

--- a/backend/src/unix_platform.hpp
+++ b/backend/src/unix_platform.hpp
@@ -61,7 +61,9 @@ public:
     int err;
     struct stat file_stat;
 
-    err = stat(this->path().c_str(), &file_stat);
+    const string &path = this->path();
+
+    err = stat(path.c_str(), &file_stat);
     if (err == -1)
       throw runtime_error("stat() failed");
 
@@ -75,10 +77,10 @@ public:
     int err;
     int fd;
   
-    const char *path = this->path().c_str();
+    const string &path = this->path();
 
     // Open the file.
-    fd = open(path, O_RDONLY, 0);
+    fd = open(path.c_str(), O_RDONLY, 0);
     if (fd < 0)
       throw runtime_error(str(boost::format("fix_permissions: open() failed: %d.") % errno));
 

--- a/backend/src/windows_platform.cpp
+++ b/backend/src/windows_platform.cpp
@@ -27,7 +27,7 @@
 #include "pcap.h"
 using namespace std;
 
-WindowsPlatform::WindowsPlatform(vector<string>)
+WindowsPlatform::WindowsPlatform(string)
 {
   // FIXME
 }

--- a/backend/src/windows_platform.hpp
+++ b/backend/src/windows_platform.hpp
@@ -34,7 +34,7 @@ using namespace std;
 class WindowsPlatform : public AbstractPlatform
 {
 public:
-  WindowsPlatform(vector<string>);
+  WindowsPlatform(string);
   bool is_root();
   bool check_permissions();
   void fix_permissions();


### PR DESCRIPTION
The pattern:

```
const char *foo = function_returning_string().c_str();
```

is dangerous because the pointer lives only as long as the temporary string returned by the function (i.e., the end of the statement), so using 'foo' leads to a use-after-free.

Fixed that by doing:

```
const string &foo = function_returning_string();
...
function_taking_pointer(foo.c_str());
```

instead. This is safe because binding a temporary to a const reference makes that temporary live for the whole block.

Also removed some other unnecessary calls to c_str().
